### PR TITLE
Custom sorting lib

### DIFF
--- a/experiments/sorting/Dockerfile
+++ b/experiments/sorting/Dockerfile
@@ -1,0 +1,10 @@
+FROM graphfuzz_base
+
+COPY in /harness/in
+WORKDIR /harness/in
+
+RUN ./build_lib.sh && ./build.sh
+
+ENV ASAN_OPTIONS=detect_leaks=0
+ENV ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
+CMD /bin/zsh

--- a/experiments/sorting/in/build.sh
+++ b/experiments/sorting/in/build.sh
@@ -1,0 +1,17 @@
+cd fuzz
+
+# gfuzz gen cpp schema.yaml .
+
+clang++ \
+    fuzz_exec.cpp \
+    -I../lib -L../lib \
+    -lsorting -lgraphfuzz -lprotobuf \
+    -fsanitize=fuzzer,address \
+    -o fuzz_exec
+
+clang++ \
+    fuzz_write.cpp \
+    -I../lib -L../lib \
+    -lsorting -lgraphfuzz -lprotobuf \
+    -fsanitize=fuzzer,address \
+    -o fuzz_write

--- a/experiments/sorting/in/build_lib.sh
+++ b/experiments/sorting/in/build_lib.sh
@@ -1,0 +1,5 @@
+
+cd lib
+clang++ -c sorting.cpp
+ar rcs libsorting.a sorting.o
+# llvm-ar-6.0 rc libsorting.a sorting.o

--- a/experiments/sorting/in/fuzz/schema.yaml
+++ b/experiments/sorting/in/fuzz/schema.yaml
@@ -1,0 +1,29 @@
+struct_Sort:
+  type: struct
+  name: Sort
+  alloc_with_new: true
+  headers:
+  - sorting.h
+  - vector
+  methods:
+  - Sort()
+  - ~Sort()
+  - int* qSortWrapper(int *arr, int n):
+      inputs: ['Sort']
+      outputs: []
+      args: ['int[1000]', 'int']
+      exec: |
+        $i0->qSortWrapper($a0, $a1);
+  - int* bubbleSortWrapper(int *arr, int n):
+      inputs: ['Sort']
+      outputs: []
+      args: ['int[1000]', 'int']
+      exec: |
+        $i0->bubbleSortWrapper($a0, $a1);
+  - int* mergeSortWrapper(int *arr, int n):
+      inputs: ['Sort']
+      outputs: []
+      args: ['int[1000]', 'int']
+      exec: |
+        $i0->mergeSortWrapper($a0, $a1);
+    

--- a/experiments/sorting/in/lib/sorting.cpp
+++ b/experiments/sorting/in/lib/sorting.cpp
@@ -1,0 +1,120 @@
+#include "sorting.h"
+#include <vector>
+
+void merge(std::vector<int>& arr, int low, int mid, int high) {
+    int i = low, j = mid + 1, k = 0;
+    std::vector<int> temp(high - low + 1);
+
+    while (i <= mid && j <= high) {
+        if (arr[i] <= arr[j]) {
+            temp[k++] = arr[i++];
+        }
+        else {
+            temp[k++] = arr[j++];
+        }
+    }
+
+    while (i <= mid) {
+        temp[k++] = arr[i++];
+    }
+
+    while (j <= high) {
+        temp[k++] = arr[j++];
+    }
+
+    for (i = low; i <= high; i++) {
+        arr[i] = temp[i - low];
+    }
+}
+
+void mergeSortInPlace(std::vector<int>& arr, int low, int high) {
+    if (low < high) {
+        int mid = (low + high) / 2;
+        mergeSortInPlace(arr, low, mid);
+        mergeSortInPlace(arr, mid + 1, high);
+        merge(arr, low, mid, high);
+    }
+}
+
+std::vector<int> mergeSort(std::vector<int>& arr) {
+    std::vector<int> res(arr);
+    mergeSortInPlace(res, 0, res.size() - 1);
+    return res;
+}
+
+std::vector<int> bubbleSort(std::vector<int>& arr) {
+    std::vector<int> res(arr);
+    int n = res.size();
+    for (int i = 0; i < n - 1; i++) {
+        for (int j = 0; j < n - i - 1; j++) {
+            if (res[j] > res[j + 1]) {
+                std::swap(res[j], res[j + 1]);
+            }
+        }
+    }
+    return res;
+}
+
+
+
+int partition(std::vector<int>& arr, int low, int high) {
+    int pivot = arr[high];
+    int i = low - 1;
+
+    for (int j = low; j <= high - 1; j++) {
+        if (arr[j] < pivot) {
+            i++;
+            std::swap(arr[i], arr[j]);
+        }
+    }
+
+    std::swap(arr[i + 1], arr[high]);
+    return i + 1;
+}
+
+void quickSortInPlace(std::vector<int>& arr, int low, int high) {
+    if (low < high) {
+        int pi = partition(arr, low, high);
+        quickSortInPlace(arr, low, pi - 1);
+        quickSortInPlace(arr, pi + 1, high);
+    }
+}
+
+std::vector<int> quickSort(std::vector<int>& arr) {
+    std::vector<int> res(arr);
+    quickSortInPlace(res, 0, res.size() - 1);
+    return res;
+}
+
+int* Sort::bubbleSortWrapper(int* arr, int n) {
+    std::vector<int> in(arr, arr + n);
+    std::vector<int> out;
+    out = bubbleSort(in);
+    int* outArr = new int[n];
+    for (int i = 0; i < n; i++) {
+        outArr[i] = out[i];
+    }
+    return outArr;
+}
+
+int* Sort::mergeSortWrapper(int* arr, int n) {
+    std::vector<int> in(arr, arr + n);
+    std::vector<int> out;
+    out = mergeSort(in);
+    int* outArr = new int[n];
+    for (int i = 0; i < n; i++) {
+        outArr[i] = out[i];
+    }
+    return outArr;
+}
+
+int* Sort::qSortWrapper(int* arr, int n) {
+    std::vector<int> in(arr, arr + n);
+    std::vector<int> out;
+    out = quickSort(in);
+    int* outArr = new int[n];
+    for (int i = 0; i < n; i++) {
+        outArr[i] = out[i];
+    }
+    return outArr;
+}

--- a/experiments/sorting/in/lib/sorting.h
+++ b/experiments/sorting/in/lib/sorting.h
@@ -1,0 +1,13 @@
+#ifndef SORTING_H
+#define SORTING_H
+#include <vector>
+
+class Sort {
+public:
+    Sort() {}
+    int* bubbleSortWrapper(int* arr, int n);
+    int* mergeSortWrapper(int* arr, int n);
+    int* qSortWrapper(int* arr, int n);
+};
+
+#endif

--- a/experiments/sorting/make_schema.sh
+++ b/experiments/sorting/make_schema.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Context is graphfuzz/experiments/ex_auto_cpp
+pdir=$( cd "$(dirname "${BASH_SOURCE[0]}")" ; pwd -P )
+cd "$pdir"
+
+# Run Doxygen to extract C++ metadata:
+mkdir -p ./doxygen_output
+gfuzz doxygen --inputs ./in/lib --output ./doxygen_output
+
+# Process the Doxygen XML and generate a GraphFuzz schema:
+gfuzz schema infer ./doxygen_output/xml ./in/auto_schema.yaml
+
+# Cleanup doxygen output:
+rm -rf ./doxygen_output
+
+# Generate fuzzer harnesses from the schema:
+mkdir -p ./in/fuzz
+gfuzz gen cpp ./in/auto_schema.yaml ./in/fuzz


### PR DESCRIPTION
**Changes**

- Add custom sorting lib experiments/sorting/lib
- Add Docker script for sorting experiment
- Add script build_lib.sh to build custom sorting lib.
- Add script build.sh to build graphFuzz artifacts, i.efuzz_exec and fuzz_write
- Add script make_schema.sh to generate auto schema.yaml

**Testing**
Instructions to run GraphFuzz https://hgarrereyn.github.io/GraphFuzz/#/quick_start/basic_usage

- Navigate to experiments folder
- Install docker if needed
- Build base docker image to install essential dependencies by running ./build base
1. To auto-generate `schema.yaml
- Make the make_schema.sh script executable by running
```
chmod u+x make_schema.sh
```
- Then run the script, which would output an auto-generated schema called auto_schema.yaml under the /in folder.
```
./make_schema.sh
```

2. Build the sorting experiment, which in turn builds the sorting library and builds the GraphFuzz artifacts i.e fuzz_exec and fuzz_write based on the auto-generated schema in step 1.
```
./build sorting
```
However, the GraphFuzz build would not be successful since all the sorting functions expect to receive an array of int as the first argument. Hence, fuzz_exec and fuzz_write object would not be created. This could be fixed by using the manually written schema in step 4, which is the updated version of the auto_schema with more information about each function's arguments.

![image](https://github.com/andrew-theturtle/GraphFuzz/assets/62633701/8785adfb-f82d-4659-ae88-e9b166f61f0c)


3. Run the sorting docker image generated by step 2
```
./run sorting
```

4. If you prefer to use the manually written schema fuzz/schema.yaml to build the GraphFuzz artifacts, then navigate to /fuzz folder and run
```
gfuzz gen cpp schema.yaml .
```
5. To run fuzzing, navigate to /fuzz folder and execute
```
./fuzz_exec
```
6. If a crash is found in the previous step, we could use fuzz_write harness to synthesize source code from graph
```
./fuzz_write <crash-file>
```